### PR TITLE
Provide correct link to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ urlFragment: ms-identity-python-webapp
 
 ## About this sample
 
-> This sample is also available as a quickstart for the Microsoft identity platform: [Quickstart: Add sign-in with Microsoft to a Python web app]("insert_url_here")
+> This sample is also available as a quickstart for the Microsoft identity platform:
+[Quickstart: Add sign-in with Microsoft to a Python web app]("https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v2-python-webapp")
 
 ### Overview
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ urlFragment: ms-identity-python-webapp
 ## About this sample
 
 > This sample is also available as a quickstart for the Microsoft identity platform:
-[Quickstart: Add sign-in with Microsoft to a Python web app]("https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v2-python-webapp")
+[Quickstart: Add sign-in with Microsoft to a Python web app]("https://docs.microsoft.com/azure/active-directory/develop/quickstart-v2-python-webapp")
 
 ### Overview
 


### PR DESCRIPTION
The previous dead link was a placeholder put in before the QuickStart was published.

This fixes #8 