### PR TITLE
Workaround for abandoned upstream project flask-session

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=1,<2
-Flask-Session>=0,<1
+git+https://github.com/rayluo/flask-session@0.3.x#egg=flask-session
 requests>=2,<3
 msal>=0,<2
 


### PR DESCRIPTION
Inspired by the conversation happened in #16, especially from @frost199 and @Alshafei2430, and then @filak, this is a reusable workaround to fix #16. The actual workaround is hosted [here](https://github.com/rayluo/flask-session#whats-new).


How to use/test
----------------------

1. `pip uninstall flask-session`  # This step is only needed when/if an end user started from our old version. New user would not need this.
2. Download the new sample and then setup as usual `pip install -r requirements.txt`
3. Enjoy
