### PR TITLE
Remove placeholder scopes in B2C config

### DIFF
--- a/app_config_b2c.py
+++ b/app_config_b2c.py
@@ -30,7 +30,7 @@ REDIRECT_PATH = "/getAToken"  # It will be used to form an absolute URL
 ENDPOINT = ''
 
 # These are the scopes that you defined for the web API
-SCOPE = ["demo.read", "demo.write"]
+SCOPE = []  # For illustration purposes only: ["demo.read", "demo.write"]
 
 SESSION_TYPE = "filesystem"  # So token cache will be stored in server-side session
 


### PR DESCRIPTION
Quoted from #29:

> in the current sample, if a developer updates just the CLIENT_ID in app_config.py (after renaming it from app_config_b2c.py, of course), several errors occur when navigating to the application and attempting to sign in, and the experience is busted.

That is because our placeholder B2C api scopes mismatch the actual scopes the customer has setup.

This is a short term workaround for #29, by not attempting to require consent for non-exist scopes during initial login.