### PR TITLE
Reorder config vars + comment edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,10 @@ In the steps below, "ClientID" is the same as "Application ID" or "AppId".
 $ pip install -r requirements.txt
 ```
 
-Run app.py from shell or command line. Note that the port needs to match what you've set up in your redirect_uri:
+Run app.py from shell or command line. Note that the host and port values need to match what you've set up in your redirect_uri:
+
 ```Shell
-$ flask run --port 5000
+$ flask run --host localhost --port 5000
 ```
 
 ## Community Help and Support

--- a/README_B2C.md
+++ b/README_B2C.md
@@ -5,7 +5,7 @@ languages:
 - html
 products:
 - azure-active-directory
-description: "This sample demonstrates a Python web application calling a web api that is secured using Azure Active Directory."
+description: "This sample demonstrates a Python web application calling a web API that is secured using Azure Active Directory."
 urlFragment: ms-identity-python-webapp
 ---
 # Integrating B2C feature of Microsoft identity platform with a Python web application
@@ -13,48 +13,43 @@ urlFragment: ms-identity-python-webapp
 ## About this sample
 
 > This sample was initially developed as a web app to demonstrate how to
-> [Integrate Microsoft Identity Platform with a Python web application](https://github.com/Azure-Samples/ms-identity-python-webapp/blob/master/README.md).
-> The same code base can also be used to demonstrate how to
-> Integrate B2C of Microsoft identity platform with a Python web application.
-> All you need is some different steps to register your app in your own B2C tenant,
-> and then feed those different settings into the configuration file of this sample.
+> [integrate Microsoft identity platform with a Python web application](https://github.com/Azure-Samples/ms-identity-python-webapp/blob/master/README.md).
+> The same code base can also be used to demonstrate how to integrate Azure Active Directory B2C
+> in a Python web application. You need to follow a few different steps and register your app in your
+> own B2C tenant, and then feed those different settings into the configuration file of this sample.
 
 This sample covers the following:
 
-* Update the application in Azure AD B2C
-* Configure the sample to use the application
-* Enable authentication in a web application using Azure Active Directory B2C
-* Access a web API using Azure Active Directory B2C
-
+* Update the application in Azure Active Directory B2C (Azure AD B2C)
+* Configure the sample to use the application registration
+* Enable authentication in a web application using Azure AD B2C
+* Access a web API protected by Azure AD B2C
 
 ### Overview
 
-This sample demonstrates a Python web application that signs-in users with the Microsoft identity platform and calls another web api.
+This sample demonstrates a Python web application that signs in users with the Microsoft identity platform and then calls a web API.
 
 1. The python web application uses the Microsoft Authentication Library (MSAL) to obtain an access token from the Microsoft identity platform (formerly Azure AD v2.0):
-2. The access token is used as a bearer token to authenticate the user when calling the web api.
+2. The access token is used as a bearer token to authenticate the user when calling the web API.
 
 ![Overview](./ReadmeFiles/topology.png)
 
-
 ## Prerequisites
 
-1. [Create an Azure Active Directory B2C tenant](https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant)
-1. [Register an application in Azure Active Directory B2C](https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-register-applications).
-1. [Create user flows in Azure Active Directory B2C](https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-user-flows)
+1. [Create an Azure AD B2C tenant](https://docs.microsoft.com/azure/active-directory-b2c/tutorial-create-tenant)
+1. [Register an application in Azure AD B2C](https://docs.microsoft.com/azure/active-directory-b2c/tutorial-register-applications)
+1. [Create user flows in Azure AD B2C](https://docs.microsoft.com/azure/active-directory-b2c/tutorial-create-user-flows)
 1. Have [Python 2.7+ or Python 3+](https://www.python.org/downloads/) installed
-
 
 ## Update the application
 
 In the tutorial that you completed as part of the prerequisites, you [added a web application in Azure AD B2C](https://docs.microsoft.com/azure/active-directory-b2c/tutorial-register-applications).
-To enable communication with the sample in this tutorial, you need to add a redirect URI to that application in Azure AD B2C.
+To enable communication with the sample in this tutorial, you need to add a redirect URI to the registration in Azure AD B2C.
 
-* Modify an existing or add a new **Reply URL**, for example `http://localhost:5000/getAToken` or `https://your_domain.com:5000/getAToken`.
-  You could use any port or any path. Later we will set this sample to match what you register here.
-* On the properties page, record the application ID that you'll use when you configure the web application.
-* Also generate a key (client secret) for your web application. Record the key that you'll use when you configure this sample.
-
+* Modify an existing or add a new **Redirect URI**, for example `http://localhost:5000/getAToken` or `https://your_domain.com:5000/getAToken`.
+  * You can use any port or path. Later, we'll configure this sample to match what you register here.
+* On the properties page, record the **Application (client) ID** that you'll use when you configure the web application.
+* Generate a **client secret** for your web application. Record the secret's value for later use when you configure this sample.
 
 ## Configure the sample
 
@@ -66,10 +61,9 @@ From your shell or command line:
 git clone https://github.com/Azure-Samples/ms-identity-python-webapp.git
 ```
 
-or download and extract the repository .zip file.
+...or download and extract the repository's .ZIP archive.
 
-> Given that the name of the sample is quite long, you might want to clone it in a folder close to the root of your hard drive, to avoid file name length limitations when running on Windows.
-
+> TIP: To avoid hitting path length restrictions when running on Windows, you might want to clone the sample in a folder close to the root of your hard drive.
 
 ### Step 2:  Install sample dependency
 
@@ -79,11 +73,9 @@ Install the dependencies using pip:
 $ pip install -r requirements.txt
 ```
 
-### Step 3:  Configure the sample to use your Azure AD tenant
+### Step 3:  Configure the sample to use your Azure AD B2C tenant
 
-In the steps below, "ClientID" is the same as "Application ID" or "AppId".
-
-#### Configure the pythonwebapp project
+Configure the pythonwebapp project by making the following changes.
 
 > Note: if you used the setup scripts, the changes below may have been applied for you
 
@@ -92,27 +84,26 @@ In the steps below, "ClientID" is the same as "Application ID" or "AppId".
 
    * Update the value of `b2c_tenant` with the name of the Azure AD B2C tenant that you created.
      For example, replace `fabrikamb2c` with `contoso`.
-   * Replace the value of `CLIENT_ID` with the application ID that you recorded.
-   * Replace the value of `CLIENT_SECRET` with the key that you recorded.
-   * Replace the value of `signupsignin_user_flow` with `b2c_1_signupsignin1`.
-   * Replace the value of `editprofile_user_flow` with `b2c_1_profileediting1`.
-   * Replace the value of `resetpassword_user_flow` with `b2c_1_passwordreset1`.
-   * Replace the value of `REDIRECT_PATH` with the path part you set up in **Reply URL**.
+   * Replace the value of `CLIENT_ID` with the Application (client) ID that you recorded.
+   * Replace the value of `CLIENT_SECRET` with the client secret that you recorded.
+   * Replace the value of `signupsignin_user_flow` with `B2C_1_signupsignin1`.
+   * Replace the value of `editprofile_user_flow` with `B2C_1_profileediting1`.
+   * Replace the value of `resetpassword_user_flow` with `B2C_1_passwordreset1`.
+   * Replace the value of `REDIRECT_PATH` with the path part you set up in **Redirect URIs**.
      For example, `/getAToken`. It will be used by this sample app to form
-     an absolute URL which matches your full **Reply URL**.
+     an absolute URL which matches your full **Redirect URI**.
    * You do not have to configure the `ENDPOINT` and `SCOPE` right now
-
 
 ## Enable authentication
 
-Run app.py from shell or command line. Note that the port needs to match what you've set up in your **Reply URL**:
+Run app.py from shell or command line. Note that the port needs to match what you've set up in your **Redirect URI**:
+
 ```Shell
-$ flask run --port 5000
+$ flask run --host localhost --port 5000
 ```
 
 You should now be able to visit `http://localhost:5000` and use the sign-in feature.
-This is how you enable authentication in a web application using Azure Active Directory B2C.
-
+This is how you enable authentication in a web application using Azure AD B2C.
 
 ## Access a web API
 
@@ -129,8 +120,7 @@ Now you can configure this sample to access that web API.
      For example, write them as `["demo.read", "demo.write"]`.
 
 Now, re-run your web app sample, and you will find a new link showed up,
-and you can access the web API using Azure Active Directory B2C.
-
+and you can access the web API using Azure AD B2C.
 
 ## Community Help and Support
 
@@ -150,9 +140,8 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 ## More information
 
-For more information, see MSAL.Python's [conceptual documentation]("https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki"):
+For more information about MSAL for Python,see its [conceptual documentation wiki](https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki):
 
+For more information about web app scenarios on the Microsoft identity platform, see [Scenario: Web app that calls web APIs](https://docs.microsoft.com/azure/active-directory/develop/scenario-web-app-call-api-overview)
 
-For more information about web apps scenarios on the Microsoft identity platform see [Scenario: Web app that calls web APIs](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-web-app-call-api-overview)
-
-For more information about how OAuth 2.0 protocols work in this scenario and other scenarios, see [Authentication Scenarios for Azure AD](http://go.microsoft.com/fwlink/?LinkId=394414).
+For more information about how OAuth 2.0 protocols work in this and other scenarios, see [Authentication Scenarios for Azure AD](http://go.microsoft.com/fwlink/?LinkId=394414).

--- a/README_B2C.md
+++ b/README_B2C.md
@@ -96,7 +96,7 @@ Configure the pythonwebapp project by making the following changes.
 
 ## Enable authentication
 
-Run app.py from shell or command line. Note that the port needs to match what you've set up in your **Redirect URI**:
+Run app.py from shell or command line. Note that the host and port values need to match what you've set up in your **Redirect URI**:
 
 ```Shell
 $ flask run --host localhost --port 5000

--- a/app_config.py
+++ b/app_config.py
@@ -1,8 +1,10 @@
 import os
 
-CLIENT_SECRET = "Enter_the_Client_Secret_Here" # Our Quickstart uses this placeholder
-# In your production app, we recommend you to use other ways to store your secret,
-# such as KeyVault, or environment variable as described in Flask's documentation here
+CLIENT_ID = "Enter_the_Application_Id_here" # Application (client) ID of app registration
+
+CLIENT_SECRET = "Enter_the_Client_Secret_Here" # Placeholder - for use ONLY during testing.
+# In a production app, we recommend you use a more secure method of storing your secret,
+# like Azure Key Vault. Or, use an environment variable as described in Flask's documentation:
 # https://flask.palletsprojects.com/en/1.1.x/config/#configuring-from-environment-variables
 # CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 # if not CLIENT_SECRET:
@@ -11,10 +13,9 @@ CLIENT_SECRET = "Enter_the_Client_Secret_Here" # Our Quickstart uses this placeh
 AUTHORITY = "https://login.microsoftonline.com/common"  # For multi-tenant app
 # AUTHORITY = "https://login.microsoftonline.com/Enter_the_Tenant_Name_Here"
 
-CLIENT_ID = "Enter_the_Application_Id_here"
-
-REDIRECT_PATH = "/getAToken"  # It will be used to form an absolute URL
-    # And that absolute URL must match your app's redirect_uri set in AAD
+REDIRECT_PATH = "/getAToken"  # Used for forming an absolute URL to your redirect URI.
+                              # The absolute URL must match the redirect URI you set
+                              # in the app's registration in the Azure portal.
 
 # You can find more Microsoft Graph API endpoints from Graph Explorer
 # https://developer.microsoft.com/en-us/graph/graph-explorer
@@ -24,5 +25,4 @@ ENDPOINT = 'https://graph.microsoft.com/v1.0/users'  # This resource requires no
 # https://docs.microsoft.com/en-us/graph/permissions-reference
 SCOPE = ["User.ReadBasic.All"]
 
-SESSION_TYPE = "filesystem"  # So token cache will be stored in server-side session
-
+SESSION_TYPE = "filesystem"  # Specifies the token cache should be stored in server-side session

--- a/app_config_b2c.py
+++ b/app_config_b2c.py
@@ -1,9 +1,9 @@
 import os
 
 b2c_tenant = "fabrikamb2c"
-signupsignin_user_flow = "b2c_1_signupsignin1"
-editprofile_user_flow = "b2c_1_profileediting1"
-resetpassword_user_flow = "b2c_1_passwordreset1"
+signupsignin_user_flow = "B2C_1_signupsignin1"
+editprofile_user_flow = "B2C_1_profileediting1"
+resetpassword_user_flow = "B2C_1_passwordreset1"
 authority_template = "https://{tenant}.b2clogin.com/{tenant}.onmicrosoft.com/{user_flow}"
 
 CLIENT_ID = "Enter_the_Application_Id_here" # Application (client) ID of app registration

--- a/app_config_b2c.py
+++ b/app_config_b2c.py
@@ -6,9 +6,11 @@ editprofile_user_flow = "b2c_1_profileediting1"
 resetpassword_user_flow = "b2c_1_passwordreset1"
 authority_template = "https://{tenant}.b2clogin.com/{tenant}.onmicrosoft.com/{user_flow}"
 
-CLIENT_SECRET = "Enter_the_Client_Secret_Here" # Our Quickstart uses this placeholder
-# In your production app, we recommend you to use other ways to store your secret,
-# such as KeyVault, or environment variable as described in Flask's documentation here
+CLIENT_ID = "Enter_the_Application_Id_here" # Application (client) ID of app registration
+
+CLIENT_SECRET = "Enter_the_Client_Secret_Here" # Placeholder - for use ONLY during testing.
+# In a production app, we recommend you use a more secure method of storing your secret,
+# like Azure Key Vault. Or, use an environment variable as described in Flask's documentation:
 # https://flask.palletsprojects.com/en/1.1.x/config/#configuring-from-environment-variables
 # CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 # if not CLIENT_SECRET:
@@ -21,16 +23,14 @@ B2C_PROFILE_AUTHORITY = authority_template.format(
 B2C_RESET_PASSWORD_AUTHORITY = authority_template.format(
     tenant=b2c_tenant, user_flow=resetpassword_user_flow)
 
-CLIENT_ID = "Enter_the_Application_Id_here"
+REDIRECT_PATH = "/getAToken"  # Used for forming an absolute URL to your redirect URI.
+                              # The absolute URL must match the redirect URI you set
+                              # in the app's registration in the Azure portal.
 
-REDIRECT_PATH = "/getAToken"  # It will be used to form an absolute URL
-    # And that absolute URL must match your app's redirect_uri set in AAD
+# This is the API resource endpoint
+ENDPOINT = '' # Application ID URI of app registration in Azure portal
 
-# This is the resource that you are going to access in your B2C tenant
-ENDPOINT = ''
+# These are the scopes you've exposed in the web API app registration in the Azure portal
+SCOPE = []  # Example with two exposed scopes: ["demo.read", "demo.write"]
 
-# These are the scopes that you defined for the web API
-SCOPE = []  # For illustration purposes only: ["demo.read", "demo.write"]
-
-SESSION_TYPE = "filesystem"  # So token cache will be stored in server-side session
-
+SESSION_TYPE = "filesystem"  # Specifies the token cache should be stored in server-side session


### PR DESCRIPTION
Reordering the config variables a bit to align more closely with how they're typically presented in the quickstarts and tutorials on docs.microsoft.com.

No variable names ~~or values~~ are modified, just their order and the comments surrounding them.

EDIT: Also updated are the user flow variable values to match the casing (UPPERcase) of the `B2C_1_` prefix added automatically when [creating a user flow in the Azure portal](https://docs.microsoft.com/azure/active-directory-b2c/tutorial-create-user-flows).