### PR TITLE
Adding password Credentials block

### DIFF
--- a/AppCreationScripts/Apps.json
+++ b/AppCreationScripts/Apps.json
@@ -15,6 +15,11 @@
           "type": "Web"
         }
       ],
+      "passwordCredentials": [
+        {
+          "value": "{auto}"
+        }
+      ],
       "x-ms-passwordCredentials": "Auto",
       "oauth2AllowImplicitFlow": false,
       "oauth2AllowIdTokenImplicitFlow": false,


### PR DESCRIPTION
This change is needed for the quickstart to generate the client secret as per offline conversation with portal team.