### PR TITLE
Switch to new MSAL auth_code_flow API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask>=1,<2
 werkzeug>=1,<2
 flask-session~=0.3.2
 requests>=2,<3
-msal>=0.6.1,<2
+msal>=1.7,<2
 
 # cachelib==0.1  # Only need this if you are running Python 2
 # Note: This sample does NOT directly depend on cachelib.

--- a/templates/auth_error.html
+++ b/templates/auth_error.html
@@ -5,7 +5,7 @@
 
     {% if config.get("B2C_RESET_PASSWORD_AUTHORITY") and "AADB2C90118" in result.get("error_description") %}
       <!-- See also https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-reference-policies#linking-user-flows -->
-      <meta http-equiv="refresh" content='0;{{_build_auth_url(authority=config["B2C_RESET_PASSWORD_AUTHORITY"])}}'>
+      <meta http-equiv="refresh" content='0;{{_build_auth_code_flow(authority=config["B2C_RESET_PASSWORD_AUTHORITY"])["auth_uri"]}}'>
     {% endif %}
 </head>
 <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
     {% endif %}
 
     {% if config.get("B2C_PROFILE_AUTHORITY") %}
-      <li><a href='{{_build_auth_url(authority=config["B2C_PROFILE_AUTHORITY"])}}'>Edit Profile</a></li>
+      <li><a href='{{_build_auth_code_flow(authority=config["B2C_PROFILE_AUTHORITY"])["auth_uri"]}}'>Edit Profile</a></li>
     {% endif %}
 
     <li><a href="/logout">Logout</a></li>

--- a/templates/login.html
+++ b/templates/login.html
@@ -9,7 +9,7 @@
     <li><a href='{{ auth_url }}'>Sign In</a></li>
 
     {% if config.get("B2C_RESET_PASSWORD_AUTHORITY") %}
-    <li><a href='{{_build_auth_url(authority=config["B2C_RESET_PASSWORD_AUTHORITY"])}}'>Reset Password</a></li>
+    <li><a href='{{_build_auth_code_flow(authority=config["B2C_RESET_PASSWORD_AUTHORITY"])["auth_uri"]}}'>Reset Password</a></li>
     {% endif %}
 
     <hr>


### PR DESCRIPTION
This PR simplifies the current web app sample based on a [new higher-level `acquire_token_by_auth_code_flow()` API](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/276), which will be available in MSAL 1.7.0 (coming soon).

On surface, this PR shrinks the 100+ lines code base by just 6 lines. The real difference is the reduction of cognitive load in the major function `authorized()`, while providing more functionality (the PKCE protection). The table below is a comparison.

|         | Before this PR | After this PR |
| --- | --- | --- |
| OAuth2 Concepts exposed | 2 (state and code) | 0 | 
| `if` statements | 4 | 1 (plus one more exception handling) |
| exits | 4 code paths | 2 |

Other than that, the functionality of this sample remains versatile: it supports authentication, web API call, B2C authentication, B2C web API call, B2C edit profile, B2C reset password, and it will automatically pick up the PKCE feature provided by MSAL 1.7.

PR reviews are welcome, although this PR will not currently work, until MSAL 1.7 being released.