### PR TITLE
fix bad render_template line 40 app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,7 +37,7 @@ def authorized():
         result = _build_msal_app(cache=cache).acquire_token_by_auth_code_flow(
             session.get("flow", {}), request.args)
         if "error" in result:
-            return render_template("error.html", result)
+            return render_template("auth_error.html", result=result)
         session["user"] = result.get("id_token_claims")
         _save_cache(cache)
     except ValueError:  # Usually caused by CSRF


### PR DESCRIPTION
line 40 of app.py was attempting to render a non existent 'error.html' template with the results incorrectly passed. 