### PR TITLE
Flask version should be 2.2.4 or less

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Our how-to docs will use --debug parameter which is only available in Flask 2.2+
-Flask>=2.2
+Flask>=2.2,<=2.2.4
 # If Flask-Session is not maintained in future, Flask-Session2 should work as well
 Flask-Session>=0.3.2,<0.5
 werkzeug>=2


### PR DESCRIPTION
session_cookie_name is deprecated in Flask version 3.x