### PR TITLE
Switch config from tenant_id to full authority

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,6 +4,7 @@
 CLIENT_ID=<client id>
 CLIENT_SECRET=<client secret>
 
-# Expects a full tenant id such as "contoso.onmicrosoft.com", or its GUID
-# Or leave it undefined if you are building a multi-tenant app
-#TENANT_ID=<tenant id>
+# Expects a full authority URL such as "https://login.microsoftonline.com/TENANT_GUID"
+# or "https://login.microsoftonline.com/contoso.onmicrosoft.com".
+# Alternatively, leave it undefined if you are building a multi-tenant app in world-wide cloud
+#AUTHORITY=<authority url>

--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 
 auth = identity.web.Auth(
     session=session,
-    authority=app.config.get("AUTHORITY"),
+    authority=app.config["AUTHORITY"],
     client_id=app.config["CLIENT_ID"],
     client_credential=app.config["CLIENT_SECRET"],
 )

--- a/app_config.py
+++ b/app_config.py
@@ -5,8 +5,9 @@ CLIENT_ID = os.getenv("CLIENT_ID")
 # Application's generated client secret: never check this into source control!
 CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 
-# AUTHORITY = "https://login.microsoftonline.com/common"  # For multi-tenant app
-AUTHORITY = f"https://login.microsoftonline.com/{os.getenv('TENANT_ID', 'common')}"
+# You can configure your authority via environment variable
+# Defaults to a multi-tenant app in world-wide cloud
+AUTHORITY = os.getenv("AUTHORITY", "https://login.microsoftonline.com/common")
 
 REDIRECT_PATH = "/getAToken"  # Used for forming an absolute URL to your redirect URI.
 # The absolute URL must match the redirect URI you set


### PR DESCRIPTION
This way, the sample is more generic to support authority of different cloud, or the upcoming CIAM product which will use authority `https://tenant.ciamlogin.com`.

@pamelafox , please:
* Review this change.
* Are there any relevant docs that need to be adjusted on your side?