### PR TITLE
Descriptive error on pathless REDIRECT_PATH

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import app_config
 
 app = Flask(__name__)
 app.config.from_object(app_config)
+assert app.config["REDIRECT_PATH"] != "/", "REDIRECT_PATH must not be /"
 Session(app)
 
 # This section is needed for url_for("foo", _external=True) to automatically


### PR DESCRIPTION
This pull request will make that [bug report](https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/561) result in a descriptive error message:

> AssertionError
>
> AssertionError: REDIRECT_PATH must not be /

CC: @AncestorComposition