### PR TITLE
Update README.md with correct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a Python web application that uses the Flask framework and the Microsoft
 To get started with this sample, you have two options:
 
 * Use the Azure portal to create the Azure AD applications and related objects. Follow the steps in
-  [Quickstart: Add sign-in with Microsoft to a Python web app](https://docs.microsoft.com/azure/active-directory/develop/web-app-quickstart?pivots=devlang-python).
+  [Quickstart: Add sign-in with Microsoft to a Python web app](https://learn.microsoft.com/entra/identity-platform/quickstart-web-app-python-sign-in).
 * Use PowerShell scripts that automatically create the Azure AD applications and related objects (passwords, permissions, dependencies) for you, and then modify the configuration files. Follow the steps in the [App Creation Scripts README](./AppCreationScripts/AppCreationScripts.md).
 
 ## If you are configuring your B2C app


### PR DESCRIPTION
Looks like the rebrand broke old links. (Learn usually has a way to redirect, but maybe not for this link?