### PR TITLE
Adopt updated dependency which comes with template

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import os
 import requests
 from flask import Flask, render_template
-from ms_identity_python.flask import Auth  # pip install "ms_identity_python[flask] @ git+https://github.com/azure-samples/ms-identity-python@0.8"
+from identity.flask import Auth
 import app_config
 
 __version__ = "0.9.0"  # The version of this sample, for troubleshooting purpose

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Our how-to docs will use --debug parameter which is only available in Flask 2.2+
 Flask>=2.2
 requests>=2,<3
-ms_identity_python[flask] @ git+https://github.com/azure-samples/ms-identity-python@0.8
+ms_identity_python[flask] @ https://github.com/azure-samples/ms-identity-python/archive/refs/heads/0.9.zip
 python-dotenv<0.22

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,17 @@
+from jinja2.exceptions import TemplateNotFound
+import pytest
+
+# Note: This test file needs to be located in the same folder as the app.py
+from app import app
+
+
+def test_login_attempt_should_render_its_template():
+    app.config.update(TESTING=True)  # Otherwise exceptions will not be thrown
+    try:
+        response = app.test_client().get("/")
+        print(response.data)  # Typically a configuration error page rendered from template
+    except TemplateNotFound:
+        pytest.fail(
+            "Template should be accessible, "
+            "typically came from inside the Identity package.")
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+env_list =
+    py3
+minversion = 4.21.2
+
+[testenv]
+description = run the tests with pytest
+package = wheel
+wheel_build_env = .pkg
+deps =
+    pytest>=6
+    -r requirements.txt
+skip_install = true  # To bypass the error "Multiple top-level packages discovered"
+commands =
+    pip list
+    pytest {tty:--color=yes} {posargs}
+


### PR DESCRIPTION
This repo does not contain a couple of templates such as `login.html`, because they are expected to be provided by the `identity` package. There was a regression in that dependency package, now been fixed. This PR here adopts that fix, and also adding test case to guard against similar issue.

This PR will close #153 and close #154 .

Volunteers are welcome to test this PR and give a thumbs up if it works for them.